### PR TITLE
Check for and install packages required by DB2.

### DIFF
--- a/bigfix/redhat/server.sh
+++ b/bigfix/redhat/server.sh
@@ -28,6 +28,9 @@ rm -f ServerInstaller_*-rhe6.x86_64.tgz
 rpm -qa | grep -q fontconfig || yum install -y fontconfig.x86_64
 rpm -qa | grep -q libXext || yum install -y libXext.x86_64
 rpm -qa | grep -q libXrender || yum install -y libXrender.x86_64
+# The following i686 packages required by DB2 install
+rpm -qa | grep -q "^pam.*i686$" || yum install -y pam pam.i686
+rpm -qa | grep -q "^libstdc++.*i686$" || yum install -y libstdc++ libstdc++.i686
 
 curl -s http://builds.sfolab.ibm.com/devtools/webui/license.pvk -o /home/vagrant/license.pvk
 curl -s http://builds.sfolab.ibm.com/devtools/webui/license.crt -o /home/vagrant/license.crt


### PR DESCRIPTION
DB2 install requires the i686 versions of the packages `pam` and `libstdc++`. Add a check and install for them.